### PR TITLE
Cases of PUT / DELETE  HTTP methods

### DIFF
--- a/dist/hyperagent.js
+++ b/dist/hyperagent.js
@@ -279,8 +279,8 @@ define("hyperagent/properties",
       // one large object for defineProperties first and call on that in the end
       // and if that would make the code cleaner.
       options = options || {};
-      if (Object(response) !== response) {
-        throw new Error('The Properties argument must be an object.');
+      if (!response) {
+        response = {};
       }
       // Overwrite the response object with the original properties if provided.
       config._.defaults(response, options.original || {});

--- a/lib/hyperagent/properties.js
+++ b/lib/hyperagent/properties.js
@@ -5,8 +5,8 @@ export function Properties(response, options) {
   // one large object for defineProperties first and call on that in the end
   // and if that would make the code cleaner.
   options = options || {};
-  if (Object(response) !== response) {
-    throw new Error('The Properties argument must be an object.');
+  if (!response) {
+    response = {};
   }
   // Overwrite the response object with the original properties if provided.
   config._.defaults(response, options.original || {});


### PR DESCRIPTION
Hi,

in Cases of PUT / DELETE  HTTP methods, in REST architecture, there is not response from backend in payload (only HTTP status), however, actually, the response is checked if it is an object. If not, an error is thrown "The Properties argument must be an object.".
It seems that is not correct.

Thx.
