### PR TITLE
fix(miniscore): _.defaults behavior for null (#41)

### DIFF
--- a/lib/hyperagent/miniscore.js
+++ b/lib/hyperagent/miniscore.js
@@ -73,7 +73,7 @@ _.defaults = function (obj) {
   _.each(Array.prototype.slice.call(arguments, 1), function (source) {
     if (source) {
       for (var prop in source) {
-        if (obj[prop] === null || obj[prop] === undefined) {
+        if (obj[prop] === undefined) {
           obj[prop] = source[prop];
         }
       }


### PR DESCRIPTION
Adjust the _.defaults behavior to match that of underscore and lodash to
no longer treat `null` and `undefined` the same and only consider
`undefined` for override.

Fix #41

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/weluse/hyperagent/43)

<!-- Reviewable:end -->
